### PR TITLE
Add support to ArchLinux based distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ Get started with one command (linux):
 sh -c "$(wget https://raw.githubusercontent.com/AmineDjeghri/awesome-os-setup/main/docs/unix_workflow/setup_linux.sh -O -)"
 ```
 
+## Arch Linux / Arch-based (yay)
+
+The interactive app also supports **Arch Linux and Arch-based distros** (e.g. Manjaro, EndeavourOS, Garuda, CachyOS)
+by using `yay` for package installation.
+
+- If `yay` is missing, the app will attempt to bootstrap it (requires non-interactive `sudo`).
+- Package list is configured in `src/awesome_os/config/packages.yaml` under `packages.arch.yay`.
+
 ## 3. TV setup
 
 - **My TV setup docs**: Read me about it

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,13 @@ Get started with one command (linux):
 sh -c "$(wget https://raw.githubusercontent.com/AmineDjeghri/awesome-os-setup/main/docs/unix_workflow/setup_linux.sh -O -)"
 ```
 
+## Arch Linux / Arch-based (yay)
+
+The interactive app supports **Arch Linux and Arch-based distros** by using `yay` for package installation.
+
+- If `yay` is missing, the app will attempt to install it (requires non-interactive `sudo`).
+- Edit the package list in `src/awesome_os/config/packages.yaml` under `packages.arch.yay`.
+
 ## 3. TV setup
 
 - **My TV setup docs**: Read me about it

--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,36 @@ else
     fi
 fi
 
+# Log everything to a timestamped file inside .logs/
+mkdir -p .logs
+LOGFILE=".logs/install_$(date +%Y%m%d_%H%M%S).log"
+echo "📝 Logging to: $LOGFILE"
 
-make install
-make run
+# NOTE: The UI (TermTk) requires a real TTY. Redirecting stdout/stderr to `tee`
+# makes stdout a pipe and breaks terminal ioctls inside some containers/TTYs.
+#
+# Strategy:
+# - Log non-interactive steps with `tee`
+# - Run the interactive UI under `script(1)` when available (provides a pty)
+if [ -t 1 ]; then
+  # Save original stdout/stderr
+  exec 3>&1 4>&2
+  # Log setup output
+  exec > >(tee -a "$LOGFILE") 2>&1
+  make install
+  # Restore TTY for the UI
+  exec 1>&3 2>&4
+
+  if command -v script >/dev/null 2>&1; then
+    # Append UI session output to the same logfile while preserving a pty.
+    script -q -a -c "make run" "$LOGFILE"
+  else
+    echo "⚠️  'script' not found; running UI without tee logging to preserve TTY."
+    make run
+  fi
+else
+  # Non-interactive environments: safe to tee everything.
+  exec > >(tee -a "$LOGFILE") 2>&1
+  make install
+  make run
+fi

--- a/makefiles/dev.mk
+++ b/makefiles/dev.mk
@@ -5,7 +5,7 @@
 
 run: ## Run the Stremio Addon (Dev Mode)
 	@echo "Starting server..."
-	uv run python src/awesome_os/frontend/main.py
+	@$(UV) run python src/awesome_os/frontend/main.py
 
 pre-commit-install:
 	@echo "${YELLOW}=========> Installing pre-commit...${NC}"
@@ -17,8 +17,8 @@ pre-commit: pre-commit-install ## Run pre-commit
 
 lint: ## Lint code with Ruff
 	@echo "Linting code..."
-	uv run ruff check .
+	@$(UV) run ruff check .
 
 format: ## Format code with Ruff
 	@echo "Formatting code..."
-	uv run ruff format .
+	@$(UV) run ruff format .

--- a/makefiles/install.mk
+++ b/makefiles/install.mk
@@ -28,7 +28,7 @@ endif
 
 install: install-uv ## Install dependencies using uv
 	@echo "Installing dependencies (required and docs)..."
-	uv sync
+	@$(UV) sync
 	@echo "${GREEN}Dependencies installed.${NC}"
 
 install-dev: install-uv ## Install dev dependencies using uv

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -9,4 +9,10 @@ test-installation: ## Test installation
 
 test: ## Run tests with pytest
 	@echo "${YELLOW}Running tests...${NC}"
-	@$(UV) run pytest tests
+	@set -e; \
+	$(UV) run pytest tests || rc=$$?; \
+	if [ "$${rc:-0}" -eq 5 ]; then \
+		echo "${YELLOW}No tests collected (pytest exit code 5) — treating as success.${NC}"; \
+	else \
+		exit "$${rc:-0}"; \
+	fi

--- a/src/awesome_os/__init__.py
+++ b/src/awesome_os/__init__.py
@@ -1,19 +1,43 @@
 # Initialize settings and configure logging
+from __future__ import annotations
+
 import sys
+from datetime import datetime
+from pathlib import Path
 
 from awesome_os.env_settings import Settings
 
 from loguru import logger as loguru_logger
 
 
+LOG_FILE_PATH: Path | None = None
+
+
 def initialize():
     settings = Settings()
     loguru_logger.remove()
 
-    if settings.DEV_MODE:
-        loguru_logger.add(sys.stderr, level="TRACE")
-    else:
-        loguru_logger.add(sys.stderr, level="INFO")
+    # Console sink: keep it readable.
+    loguru_logger.add(sys.stderr, level="TRACE" if settings.DEV_MODE else "INFO")
+
+    # File sink: always capture verbose logs so we can debug installs after the fact.
+    global LOG_FILE_PATH
+    try:
+        logs_dir = Path.cwd() / ".logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        LOG_FILE_PATH = logs_dir / f"awesome-os_{ts}.log"
+        loguru_logger.add(
+            str(LOG_FILE_PATH),
+            level="TRACE" if settings.DEV_MODE else "DEBUG",
+            enqueue=True,
+            backtrace=True,
+            diagnose=True,
+        )
+    except Exception as e:  # noqa: BLE001
+        # If we can't write logs, don't prevent the app from starting.
+        LOG_FILE_PATH = None
+        loguru_logger.warning(f"Failed to initialize file logging: {e}")
 
     return settings, loguru_logger
 

--- a/src/awesome_os/config/packages.yaml
+++ b/src/awesome_os/config/packages.yaml
@@ -14,21 +14,34 @@ packages:
       apps:
         - code
   darwin:
-    brews:
-      - 'git'
-      - 'zsh'
-    casks:
-      - 'brave-browser'
-      - 'raycast'
-      - 'ghostty'
-      - 'jordanbaird-ice' # Menu bar management tool
-      - 'shottr'
-      - 'swift-quit'
-      - 'alt-tab'
-      - 'anydesk'
-      - 'obsidian'
-      - 'zed'
-      - 'discord'
+    brew:
+      core:
+        - git
+        - zsh
+    cask:
+      apps:
+        - brave-browser
+        - raycast
+        - ghostty
+        - jordanbaird-ice # Menu bar management tool
+        - shottr
+        - swift-quit
+        - alt-tab
+        - anydesk
+        - obsidian
+        - zed
+        - discord
+  arch:
+    yay:
+      core:
+        - git
+        - curl
+        - zsh
+      terminal_tools:
+        - bat
+        - fzf
+        - btop
+        - neofetch
   windows:
     winget:
       core:

--- a/src/awesome_os/config/packages.yaml
+++ b/src/awesome_os/config/packages.yaml
@@ -14,11 +14,11 @@ packages:
       apps:
         - code
   darwin:
-    brew:
+    brews:
       core:
         - git
         - zsh
-    cask:
+    casks:
       apps:
         - brave-browser
         - raycast
@@ -42,6 +42,29 @@ packages:
         - fzf
         - btop
         - neofetch
+        - eza
+        - lsd
+        - ripgrep
+        - tldr
+        - zoxide
+        - docker
+        - lazygit
+        - lazydocker
+        - tmux
+        - neovim
+        - python
+        - bpytop
+        - fd
+        - opencode
+      apps:
+        - brave-browser
+        - vicinae
+        - ghostty
+        - steam
+        - obsidian
+        - vlc
+        - wine
+        - vesktop
   windows:
     winget:
       core:

--- a/src/awesome_os/detect_os.py
+++ b/src/awesome_os/detect_os.py
@@ -66,6 +66,20 @@ def detect_os() -> OSInfo:
                 data[k.strip()] = v.strip().strip('"')
 
             distro = data.get("ID", "linux").lower()
+            id_like = data.get("ID_LIKE", "").lower()
+
+            # Normalize Arch-based distros to a single identifier so we can use one package
+            # catalog and one package-manager backend.
+            arch_like_ids = {
+                "arch",
+                "manjaro",
+                "endeavouros",
+                "garuda",
+                "arcolinux",
+                "cachyos",
+            }
+            if distro in arch_like_ids or "arch" in id_like.split():
+                distro = "arch"
         return OSInfo(
             family=system, distro=distro, info="OS running inside WSL" if _is_wsl() else None
         )

--- a/src/awesome_os/tasks/factory.py
+++ b/src/awesome_os/tasks/factory.py
@@ -7,6 +7,7 @@ from typing import Callable
 from pydantic import BaseModel, ConfigDict
 
 from awesome_os.tasks.managers.darwin_brew import DarwinBrewManager, DarwinBrewCaskManager
+from awesome_os.tasks.managers.arch_yay import ArchYayManager
 from awesome_os.tasks.system.help import show_commands
 from awesome_os.tasks.system.zsh import (
     apply_p10k_force,
@@ -53,6 +54,7 @@ _PACKAGE_MANAGER_FACTORY_BY_DISTRO: dict[str, dict[str, Callable[[], PackageMana
     "ubuntu": {"apt": UbuntuAptManager, "snap": UbuntuSnapManager},
     "darwin": {"brew": DarwinBrewManager, "cask": DarwinBrewCaskManager},
     "windows": {"winget": WindowsWingetManager},
+    "arch": {"yay": ArchYayManager},
 }
 
 

--- a/src/awesome_os/tasks/managers/arch_yay.py
+++ b/src/awesome_os/tasks/managers/arch_yay.py
@@ -119,11 +119,15 @@ class ArchYayManager:
     def install(self, package: str) -> InstallResult:
         ensure = self._ensure_yay()
         if not ensure.ok:
-            return InstallResult(ok=False, summary=f"{package}: install failed (yay missing)", details=ensure.details)
+            return InstallResult(
+                ok=False, summary=f"{package}: install failed (yay missing)", details=ensure.details
+            )
 
         yay = self._yay()
         if yay is None:
-            return InstallResult(ok=False, summary="yay not found on PATH", details="Ensure `yay` is installed.")
+            return InstallResult(
+                ok=False, summary="yay not found on PATH", details="Ensure `yay` is installed."
+            )
 
         logger.info(f"Installing {package} via yay...")
         res = run([yay, "-S", "--needed", "--noconfirm", package], check=False)
@@ -141,11 +145,17 @@ class ArchYayManager:
             return TaskResult(ok=False, summary="yay update: failed", details=ensure.details)
         yay = self._yay()
         if yay is None:
-            return TaskResult(ok=False, summary="yay update: failed", details="yay not found on PATH")
+            return TaskResult(
+                ok=False, summary="yay update: failed", details="yay not found on PATH"
+            )
         res = run([yay, "-Sy", "--noconfirm"], check=False)
         if res.returncode == 0:
             return TaskResult(ok=True, summary="yay sync: done")
-        return TaskResult(ok=False, summary="yay sync: failed", details=_format_failed(res.argv, res.stdout, res.stderr))
+        return TaskResult(
+            ok=False,
+            summary="yay sync: failed",
+            details=_format_failed(res.argv, res.stdout, res.stderr),
+        )
 
     def upgrade(self) -> TaskResult:
         ensure = self._ensure_yay()
@@ -153,11 +163,17 @@ class ArchYayManager:
             return TaskResult(ok=False, summary="yay upgrade: failed", details=ensure.details)
         yay = self._yay()
         if yay is None:
-            return TaskResult(ok=False, summary="yay upgrade: failed", details="yay not found on PATH")
+            return TaskResult(
+                ok=False, summary="yay upgrade: failed", details="yay not found on PATH"
+            )
         res = run([yay, "-Syu", "--noconfirm"], check=False)
         if res.returncode == 0:
             return TaskResult(ok=True, summary="yay -Syu: done")
-        return TaskResult(ok=False, summary="yay -Syu: failed", details=_format_failed(res.argv, res.stdout, res.stderr))
+        return TaskResult(
+            ok=False,
+            summary="yay -Syu: failed",
+            details=_format_failed(res.argv, res.stdout, res.stderr),
+        )
 
     def cleanup(self) -> TaskResult:
         ensure = self._ensure_yay()
@@ -165,10 +181,15 @@ class ArchYayManager:
             return TaskResult(ok=False, summary="yay cleanup: failed", details=ensure.details)
         yay = self._yay()
         if yay is None:
-            return TaskResult(ok=False, summary="yay cleanup: failed", details="yay not found on PATH")
+            return TaskResult(
+                ok=False, summary="yay cleanup: failed", details="yay not found on PATH"
+            )
         # `-Sc` removes unused packages from cache. `--noconfirm` to avoid prompts.
         res = run([yay, "-Sc", "--noconfirm"], check=False)
         if res.returncode == 0:
             return TaskResult(ok=True, summary="yay cache cleanup: done")
-        return TaskResult(ok=False, summary="yay cache cleanup: failed", details=_format_failed(res.argv, res.stdout, res.stderr))
-
+        return TaskResult(
+            ok=False,
+            summary="yay cache cleanup: failed",
+            details=_format_failed(res.argv, res.stdout, res.stderr),
+        )

--- a/src/awesome_os/tasks/managers/arch_yay.py
+++ b/src/awesome_os/tasks/managers/arch_yay.py
@@ -1,0 +1,174 @@
+"""Arch Linux `yay` package manager backend.
+
+This backend supports Arch and Arch-based distros by:
+- bootstrapping `yay` if missing (requires non-interactive sudo)
+- installing packages via `yay -S --needed --noconfirm`
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+from awesome_os import logger
+from awesome_os.tasks.commands import join_argv, run
+from awesome_os.tasks.managers.base import InstallResult
+from awesome_os.tasks.task import TaskResult
+
+
+def _sudo_non_interactive_ok() -> bool:
+    """Return True if `sudo -n` is usable (no password prompt)."""
+    res = run(["sudo", "-n", "true"], check=False)
+    return res.returncode == 0
+
+
+def _format_failed(argv: list[str], stdout: str, stderr: str) -> str:
+    details = [f"$ {join_argv(argv)}"]
+    if stdout.strip():
+        details.append(stdout.strip())
+    if stderr.strip():
+        details.append(stderr.strip())
+    return "\n".join(details).strip()
+
+
+class ArchYayManager:
+    """`yay` manager for Arch Linux and Arch-based distros."""
+
+    name = "yay"
+
+    def _yay(self) -> str | None:
+        return shutil.which("yay")
+
+    def _ensure_yay(self) -> TaskResult:
+        yay = self._yay()
+        if yay is not None:
+            return TaskResult(ok=True, summary="yay: found")
+
+        if not _sudo_non_interactive_ok():
+            return TaskResult(
+                ok=False,
+                summary="yay: missing (sudo password required)",
+                details=(
+                    "This app runs non-interactively; it cannot prompt for your sudo password.\n"
+                    "Install yay manually, then re-run:\n"
+                    "  sudo pacman -Sy --needed base-devel git\n"
+                    "  cd /tmp && git clone https://aur.archlinux.org/yay.git\n"
+                    "  cd yay && makepkg -si\n"
+                ),
+            )
+
+        # Ensure build tooling exists.
+        res = run(
+            ["sudo", "-n", "pacman", "-Sy", "--needed", "--noconfirm", "base-devel", "git"],
+            check=False,
+        )
+        if res.returncode != 0:
+            return TaskResult(
+                ok=False,
+                summary="yay: bootstrap failed (pacman deps)",
+                details=_format_failed(res.argv, res.stdout, res.stderr),
+            )
+
+        # Build and install yay from AUR.
+        with tempfile.TemporaryDirectory(prefix="awesome-os-yay-") as td:
+            tdir = Path(td)
+            clone = run(
+                ["git", "clone", "https://aur.archlinux.org/yay.git", str(tdir / "yay")],
+                check=False,
+            )
+            if clone.returncode != 0:
+                return TaskResult(
+                    ok=False,
+                    summary="yay: bootstrap failed (git clone)",
+                    details=_format_failed(clone.argv, clone.stdout, clone.stderr),
+                )
+
+            yay_dir = tdir / "yay"
+            # Note: `makepkg -si` will install the built package via pacman (sudo).
+            makepkg = run(
+                ["bash", "-lc", f"cd {str(yay_dir)!r} && makepkg -si --noconfirm"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if makepkg.returncode != 0:
+                return TaskResult(
+                    ok=False,
+                    summary="yay: bootstrap failed (makepkg)",
+                    details=_format_failed(makepkg.argv, makepkg.stdout, makepkg.stderr),
+                )
+
+        yay = self._yay()
+        if yay is None:
+            return TaskResult(
+                ok=False,
+                summary="yay: bootstrap finished but yay not on PATH",
+                details="`yay` was built/installed but is still not found on PATH. Restart your shell and try again.",
+            )
+        return TaskResult(ok=True, summary="yay: installed")
+
+    def is_installed(self, package: str) -> bool:
+        # Both repo and AUR packages end up in pacman's local DB.
+        pacman = shutil.which("pacman")
+        if pacman is None:
+            return False
+        res = run([pacman, "-Q", package], check=False)
+        return res.returncode == 0
+
+    def install(self, package: str) -> InstallResult:
+        ensure = self._ensure_yay()
+        if not ensure.ok:
+            return InstallResult(ok=False, summary=f"{package}: install failed (yay missing)", details=ensure.details)
+
+        yay = self._yay()
+        if yay is None:
+            return InstallResult(ok=False, summary="yay not found on PATH", details="Ensure `yay` is installed.")
+
+        logger.info(f"Installing {package} via yay...")
+        res = run([yay, "-S", "--needed", "--noconfirm", package], check=False)
+        if res.returncode == 0:
+            return InstallResult(ok=True, summary=f"{package}: installed (yay)")
+        return InstallResult(
+            ok=False,
+            summary=f"{package}: install failed (yay)",
+            details=_format_failed(res.argv, res.stdout, res.stderr),
+        )
+
+    def update(self) -> TaskResult:
+        ensure = self._ensure_yay()
+        if not ensure.ok:
+            return TaskResult(ok=False, summary="yay update: failed", details=ensure.details)
+        yay = self._yay()
+        if yay is None:
+            return TaskResult(ok=False, summary="yay update: failed", details="yay not found on PATH")
+        res = run([yay, "-Sy", "--noconfirm"], check=False)
+        if res.returncode == 0:
+            return TaskResult(ok=True, summary="yay sync: done")
+        return TaskResult(ok=False, summary="yay sync: failed", details=_format_failed(res.argv, res.stdout, res.stderr))
+
+    def upgrade(self) -> TaskResult:
+        ensure = self._ensure_yay()
+        if not ensure.ok:
+            return TaskResult(ok=False, summary="yay upgrade: failed", details=ensure.details)
+        yay = self._yay()
+        if yay is None:
+            return TaskResult(ok=False, summary="yay upgrade: failed", details="yay not found on PATH")
+        res = run([yay, "-Syu", "--noconfirm"], check=False)
+        if res.returncode == 0:
+            return TaskResult(ok=True, summary="yay -Syu: done")
+        return TaskResult(ok=False, summary="yay -Syu: failed", details=_format_failed(res.argv, res.stdout, res.stderr))
+
+    def cleanup(self) -> TaskResult:
+        ensure = self._ensure_yay()
+        if not ensure.ok:
+            return TaskResult(ok=False, summary="yay cleanup: failed", details=ensure.details)
+        yay = self._yay()
+        if yay is None:
+            return TaskResult(ok=False, summary="yay cleanup: failed", details="yay not found on PATH")
+        # `-Sc` removes unused packages from cache. `--noconfirm` to avoid prompts.
+        res = run([yay, "-Sc", "--noconfirm"], check=False)
+        if res.returncode == 0:
+            return TaskResult(ok=True, summary="yay cache cleanup: done")
+        return TaskResult(ok=False, summary="yay cache cleanup: failed", details=_format_failed(res.argv, res.stdout, res.stderr))
+

--- a/tests/archlinux/Dockerfile
+++ b/tests/archlinux/Dockerfile
@@ -29,4 +29,3 @@ VOLUME /home/tester/awesome-os-setup
 
 # Helpful default so running the container drops you into the repo.
 CMD ["bash"]
-

--- a/tests/archlinux/Dockerfile
+++ b/tests/archlinux/Dockerfile
@@ -1,0 +1,30 @@
+FROM archlinux:base
+
+# Minimal Arch sandbox image to manually test the setup.
+# - provides pacman + makepkg tooling (base-devel)
+# - creates an unprivileged user with passwordless sudo so `sudo -n` works
+# - copies this repo into the user's home so you can run install commands manually
+
+RUN pacman -Sy --noconfirm --needed \
+    base-devel \
+    git \
+    make \
+    sudo \
+    python \
+    python-pip \
+    && pacman -Scc --noconfirm
+
+# Passwordless sudo for the test user (so our code can use `sudo -n`).
+RUN useradd -m -s /bin/bash tester \
+    && echo "tester ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/tester \
+    && chmod 0440 /etc/sudoers.d/tester
+
+USER tester
+
+WORKDIR /home/tester/awesome-os-setup
+
+COPY --chown=tester:tester . /home/tester/awesome-os-setup
+
+# Helpful default so running the container drops you into the repo.
+CMD ["bash"]
+

--- a/tests/archlinux/Dockerfile
+++ b/tests/archlinux/Dockerfile
@@ -23,7 +23,9 @@ USER tester
 
 WORKDIR /home/tester/awesome-os-setup
 
-COPY --chown=tester:tester . /home/tester/awesome-os-setup
+# COPY --chown=tester:tester . /home/tester/awesome-os-setup
+# Mount local repo folder as a volume
+VOLUME /home/tester/awesome-os-setup
 
 # Helpful default so running the container drops you into the repo.
 CMD ["bash"]

--- a/tests/archlinux/README.md
+++ b/tests/archlinux/README.md
@@ -11,10 +11,10 @@ From the `awesome-os-setup/` directory:
 docker build -f tests/archlinux/Dockerfile -t awesome-os-setup-arch-test .
 ```
 
-### Run (interactive)
+### Run (interactive) and mount
 
 ```bash
-docker run --rm -it awesome-os-setup-arch-test
+docker run --rm -it -v "$(pwd):/home/tester/awesome-os-setup" awesome-os-setup-arch-test
 ```
 
 This drops you into `bash` in:

--- a/tests/archlinux/README.md
+++ b/tests/archlinux/README.md
@@ -1,0 +1,30 @@
+## Arch Linux Docker test image
+
+This folder provides a small **Arch Linux** Docker image intended as an **interactive sandbox**.
+It copies the `awesome-os-setup/` repo into the container user's home so you can jump in and run the setup manually.
+
+### Build
+
+From the `awesome-os-setup/` directory:
+
+```bash
+docker build -f tests/archlinux/Dockerfile -t awesome-os-setup-arch-test .
+```
+
+### Run (interactive)
+
+```bash
+docker run --rm -it awesome-os-setup-arch-test
+```
+
+This drops you into `bash` in:
+
+- `/home/tester/awesome-os-setup`
+
+From there you can try your normal workflow, for example:
+
+```bash
+make install
+make run
+```
+

--- a/tests/archlinux/README.md
+++ b/tests/archlinux/README.md
@@ -27,4 +27,3 @@ From there you can try your normal workflow, for example:
 make install
 make run
 ```
-

--- a/tests/archlinux/run.sh
+++ b/tests/archlinux/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME="${IMAGE_NAME:-awesome-os-setup-arch-test}"
+
+cd "$(dirname "$0")/../.." # repo root (awesome-os-setup/)
+
+docker build -f tests/archlinux/Dockerfile -t "$IMAGE_NAME" .
+docker run --rm -it "$IMAGE_NAME"
+

--- a/tests/archlinux/run.sh
+++ b/tests/archlinux/run.sh
@@ -7,4 +7,3 @@ cd "$(dirname "$0")/../.." # repo root (awesome-os-setup/)
 
 docker build -f tests/archlinux/Dockerfile -t "$IMAGE_NAME" .
 docker run --rm -it -v "$(pwd):/home/tester/awesome-os-setup" "$IMAGE_NAME"
-

--- a/tests/archlinux/run.sh
+++ b/tests/archlinux/run.sh
@@ -6,5 +6,5 @@ IMAGE_NAME="${IMAGE_NAME:-awesome-os-setup-arch-test}"
 cd "$(dirname "$0")/../.." # repo root (awesome-os-setup/)
 
 docker build -f tests/archlinux/Dockerfile -t "$IMAGE_NAME" .
-docker run --rm -it "$IMAGE_NAME"
+docker run --rm -it -v "$(pwd):/home/tester/awesome-os-setup" "$IMAGE_NAME"
 


### PR DESCRIPTION
This PR:
- adds support to Archlinux based distributions through pre-installing `yay` AUR package manager
- adds list of packages to install on Arch
- switches packages list on tui to multi-select list widget to support longer lists
- adds sample Archlinux docker container to simplify testing the dotfiles scripts
- make it possible to run `./install.sh` in one go by fixing previous Makefile error if `uv` is not already sourced in `~/.local/share/bin`
- adds automatic saving of logs in a `.logs` folder in the current working directory to avoid cases where error messages were too long to be readable in the logs box in the TUI